### PR TITLE
changed repo from ssh to https

### DIFF
--- a/A/ACEbonds/Package.toml
+++ b/A/ACEbonds/Package.toml
@@ -1,3 +1,3 @@
 name = "ACEbonds"
 uuid = "d0dfcdf4-f9d4-4d39-8ac7-72ac73934171"
-repo = "git@github.com:ACEsuit/ACEbonds.jl.git"
+repo = "https://github.com/ACEsuit/ACEbonds.jl.git"


### PR DESCRIPTION
I had issues adding packages via ssh, which doesn't seem to be an uncommon issue; see https://github.com/JuliaLang/Pkg.jl/issues/1733

Thus, I changed the repo to https format. As far as I can see the repos in all other packages in the ACE registry are in https form anyways. So, this change would help making things consistent. 