### PR TITLE
README: Recommend that users also install the General registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ This is the Julia package registry for ACEsuit packages that are still
 under heavy development. Mature packages suitable for public use will 
 generally be moved into the `General` registry. 
 
-To install open a Julia REPL and type
+To install the `ACEregistry`, open a Julia REPL and type
 ```{julia}
 ] registry add https://github.com/ACEsuit/ACEregistry.git
 ```
+
+You also want to make sure that you have the `General` registry installed:
+```{julia}
+] registry add General
+```
+
 Afterwards use the normal package manager commands to add, remove, dev, etc the packages in this registry.
 
 On Windows, there might be problems due to stalled `git clone` command. One workaround that can be


### PR DESCRIPTION
If someone has a brand-new install of Julia, if they open Julia up and install the `ACEregistry` before they run any other Pkg commands, then they can end up with only one registry installed (the `ACEregistry`). In particular, they can end up without the `General` registry installed.

This can lead the user to encounter unusual issues, such as https://github.com/JuliaAI/MLJ.jl/issues/1158.

I recommend adding the `General` registry installation instructions (`] registry add General`) to the README.